### PR TITLE
support-ids

### DIFF
--- a/__test__/fixtures.json
+++ b/__test__/fixtures.json
@@ -239,5 +239,37 @@
         "topic": "nio.5"
       }
     }
+  },
+  "id": {
+    "services": {
+      "PubService": {
+        "id": "PubService",
+        "name": "PubService--RENAMED",
+        "mapping": [],
+        "execution": [
+          { "name": "PubData" }
+        ]
+      },
+      "SubService": {
+        "id": "SubService",
+        "name": "SubService--RENAMED",
+        "mapping": [],
+        "execution": [
+          { "name": "SubData" }
+        ]
+      }
+    },
+    "blocks": {
+      "PubData": {
+        "name": "PubData",
+        "type": "Publisher",
+        "topic": "nio.data"
+      },
+      "SubData": {
+        "name": "SubData",
+        "type": "Subscriber",
+        "topic": "nio.data"
+      }
+    }
   }
 }

--- a/__test__/topic-graph-test.js
+++ b/__test__/topic-graph-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import graph from '../src';
-import { simple, circular, env, simpleLocal } from './fixtures.json'
+import { simple, circular, env, simpleLocal, id } from './fixtures.json'
 
 describe('topic graph', () => {
   describe('with a simple pub/sub', () => {
@@ -143,6 +143,18 @@ describe('topic graph', () => {
       expect(subs).to.have.length(1);
       expect(subs).to.deep.equal([
         ['SubService', 'nio.data']
+      ]);
+    });
+  });
+  describe('with an id on services', () => {
+    const result = graph(id.services, id.blocks);
+
+    it('should use the id', () => {
+      expect(result.edges).to.deep.equal([
+        ['PubService', 'SubService', 'nio.data']
+      ]);
+      expect(result.edges).to.not.deep.equal([
+        ['PubService--RENAMED', 'SubService--RENAMED', 'nio.data']
       ]);
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nio/topic-grapher",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "nio communications topic grapher",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import type {
 } from './types.js.flow';
 
 const getName = (step: ExecutionStep) => step.name;
+const getID = obj => obj.id || obj.name;
 const exists = topic => !!topic;
 
 const permute = (left: Array<string>, right: Array<string>, ...rest) => (
@@ -51,13 +52,13 @@ export default function compile(services: Services, blocks: Blocks): GraphResult
   const addLocalSubscriber = createAdder(topicToLocalSubs);
 
   Object.keys(services).forEach((key) => {
+    const _id: string = getID(services[key]);
     const {
       name,
       execution,
       mapping,
     }: ServiceShape = services[key];
-
-    nodes.add(name);
+    nodes.add(_id);
 
     const mappings: Mapping = mapping ?
       mapping.reduce((rest, { name: alias, mapping: block }) => ({
@@ -76,7 +77,7 @@ export default function compile(services: Services, blocks: Blocks): GraphResult
       .map(b => pubs[b])
       .filter(exists)
       .forEach((topic) => {
-        addPublisher(name, topic);
+        addPublisher(_id, topic);
       });
 
     // Subscribers
@@ -84,7 +85,7 @@ export default function compile(services: Services, blocks: Blocks): GraphResult
       .map(b => subs[b])
       .filter(exists)
       .forEach((topic) => {
-        addSubscriber(name, topic);
+        addSubscriber(_id, topic);
       });
 
     // LocalPublishers
@@ -92,7 +93,7 @@ export default function compile(services: Services, blocks: Blocks): GraphResult
     .map(b => localPubs[b])
     .filter(exists)
     .forEach((topic) => {
-      addLocalPublisher(name, topic);
+      addLocalPublisher(_id, topic);
     });
 
     // LocalSubscribers
@@ -100,7 +101,7 @@ export default function compile(services: Services, blocks: Blocks): GraphResult
       .map(b => localSubs[b])
       .filter(exists)
       .forEach((topic) => {
-        addLocalSubscriber(name, topic);
+        addLocalSubscriber(_id, topic);
       });
   });
 


### PR DESCRIPTION
Use the `id` of a service if it exists. Otherwise still use the name. All instances that get upgraded to `nio@3+` will automatically have an `id` added thus taking care of having to do any version checks in this library.

Open to alternatives.